### PR TITLE
De-duplicate wifi.sta.getip() call

### DIFF
--- a/httpserver.lua
+++ b/httpserver.lua
@@ -79,8 +79,9 @@ return function (port)
 
       end
    )
-   local ip = nil
-   if wifi.sta.getip() then ip = wifi.sta.getip() else ip = wifi.ap.getip() end
+   -- false and nil evaluate as false
+   local ip = wifi.sta.getip() 
+   if not ip then ip = wifi.ap.getip() end
    print("nodemcu-httpserver running at http://" .. ip .. ":" ..  port)
    return s
 


### PR DESCRIPTION
Technically, if the wifi.sta.getip() or wifi.ap.getip() call return invalid ip addresses, you shouldn't assume that it's running.  However, the lack of that type of check means that this change will function similarly without incurring another function call in a constrained stack/heap environment.
