### PR TITLE
Fix improper syntax in list

### DIFF
--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -8,7 +8,7 @@ return function (connection, code, extension)
       local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found", [501]="Not Implemented",}
       local myResult = codez[code]
       -- enforce returning valid http codes all the way throughout?
-      if myResult then return myResult else return codez[501] end
+      if myResult then return {[code]=myResult,} else return {[501]=codez[501],} end
    end
 
    local function getMimeType(ext)

--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -7,7 +7,8 @@ return function (connection, code, extension)
    local function getHTTPStatusString(code)
       local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found", [501]="Not Implemented",}
       local myResult = codez[code]
-      if myResult then return myResult else return "Unknown HTTP Status" end
+      -- enforce returning valid http codes all the way throughout?
+      if myResult then return myResult else return codez[501] end
    end
 
    local function getMimeType(ext)

--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -5,10 +5,10 @@
 return function (connection, code, extension)
 
    local function getHTTPStatusString(code)
-      local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found", [501]="Not Implemented",}
+      local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found",}
       local myResult = codez[code]
       -- enforce returning valid http codes all the way throughout?
-      if myResult then return {[code]=myResult,} else return {[501]=codez[501],} end
+      if myResult then return {[code]=myResult,} else return {[501]="Not Implemented",} end
    end
 
    local function getMimeType(ext)

--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -5,7 +5,7 @@
 return function (connection, code, extension)
 
    local function getHTTPStatusString(code)
-      local codez = {200="OK", 400="Bad Request", 404="Not Found", 501="Not Implemented"}
+      local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found", [501]="Not Implemented",}
       local myResult = codez[code]
       if myResult then return myResult else return "Unknown HTTP Status" end
    end

--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -8,7 +8,7 @@ return function (connection, code, extension)
       local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found",}
       local myResult = codez[code]
       -- enforce returning valid http codes all the way throughout?
-      if myResult then return {[code]=myResult,} else return {[501]="Not Implemented",} end
+      if myResult then return myResult else return "Not Implemented" end
    end
 
    local function getMimeType(ext)


### PR DESCRIPTION
brackets needed for non-standard table indexing.   Also added a trailing comma as its valid (and more consistent, imo).
