### PR TITLE
Use gzipped file if exists

### DIFF
--- a/httpserver.lua
+++ b/httpserver.lua
@@ -23,8 +23,21 @@ return function (port)
                fileServeFunction = dofile("httpserver-error.lc")
             else
                local fileExists = file.open(uri.file, "r")
+               file.close()			   
+            
+			if not fileExists then
+               -- gzip check
+               fileExists = file.open(uri.file .. ".gz", "r")
                file.close()
-               if not fileExists then
+
+               if fileExists then
+                  print("gzip variant exists, serving that one")
+                  uri.file = uri.file .. ".gz"
+                  uri.ext = uri.ext .. ".gz"
+               end
+            end
+			   
+            if not fileExists then
                   uri.args = {code = 404, errorString = "Not Found"}
                   fileServeFunction = dofile("httpserver-error.lc")
                elseif uri.isScript then


### PR DESCRIPTION
If foo.html is not found, foo.html.gz is checked and if exists, will served.

This will not interfere with normal requests, only if requested resource cannot be found (404) will introduce some overhead.
