### PR TITLE
File extension parsing fix

### DIFF
--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -2,7 +2,7 @@
 -- Part of nodemcu-httpserver, knows how to send an HTTP header.
 -- Author: Marcos Kirsch
 
-return function (connection, code, extension)
+return function (connection, code, extension, gzip)
 
    local function getHTTPStatusString(code)
       local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found",}
@@ -15,11 +15,6 @@ return function (connection, code, extension)
       local gzip = false
       -- A few MIME types. Keep list short. If you need something that is missing, let's add it.
       local mt = {css = "text/css", gif = "image/gif", html = "text/html", ico = "image/x-icon", jpeg = "image/jpeg", jpg = "image/jpeg", js = "application/javascript", json = "application/json", png = "image/png", xml = "text/xml"}
-      -- add comressed flag if file ends with gz
-      if ext:find("%.gz$") then
-          ext = ext:sub(1, -4)
-          gzip = true
-      end
       if mt[ext] then contentType = mt[ext] else contentType = "text/plain" end
       return {contentType = contentType, gzip = gzip}
    end
@@ -27,7 +22,7 @@ return function (connection, code, extension)
    local mimeType = getMimeType(extension)
 
    connection:send("HTTP/1.0 " .. code .. " " .. getHTTPStatusString(code) .. "\r\nServer: nodemcu-httpserver\r\nContent-Type: " .. mimeType["contentType"] .. "\r\n")
-   if mimeType["gzip"] then
+   if gzip then
        connection:send("Content-Encoding: gzip\r\n")
    end
    connection:send("Connection: close\r\n\r\n")

--- a/httpserver-request.lua
+++ b/httpserver-request.lua
@@ -44,7 +44,12 @@ local function parseUri(uri)
       filename,ext = filename:match("(.+)%.(.+)")
       table.insert(fullExt,1,ext)
    end
-   r.ext = table.concat(fullExt,".")
+   if #fullExt > 1 and fullExt[#fullExt] == 'gz' then
+      r.ext = fullExt[#fullExt-1]
+      r.isGzipped = true
+   elseif #fullExt >= 1 then
+      r.ext = fullExt[#fullExt]
+   end
    r.isScript = r.ext == "lua" or r.ext == "lc"
    r.file = uriToFilename(r.file)
    return r

--- a/httpserver-static.lua
+++ b/httpserver-static.lua
@@ -3,7 +3,7 @@
 -- Author: Marcos Kirsch
 
 return function (connection, args)
-   dofile("httpserver-header.lc")(connection, 200, args.ext)
+   dofile("httpserver-header.lc")(connection, 200, args.ext, args.gzipped)
    --print("Begin sending:", args.file)
    -- Send file in little chunks
    local continue = true

--- a/httpserver.lua
+++ b/httpserver.lua
@@ -33,7 +33,7 @@ return function (port)
                if fileExists then
                   print("gzip variant exists, serving that one")
                   uri.file = uri.file .. ".gz"
-                  uri.ext = uri.ext .. ".gz"
+                  uri.isGzipped = true
                end
             end
 			   
@@ -43,7 +43,7 @@ return function (port)
                elseif uri.isScript then
                   fileServeFunction = dofile(uri.file)
                else
-                  uri.args = {file = uri.file, ext = uri.ext}
+                  uri.args = {file = uri.file, ext = uri.ext, gzipped = uri.isGzipped}
                   fileServeFunction = dofile("httpserver-static.lc")
                end
             end


### PR DESCRIPTION
If a filename contains dots, extension was parsed as everything after the first dot.
It should be after the last dot and was causing wrong mimetype selecting for filenames like "zepto.min.js", which is common naming convention for minified javascript/css files.

Also includes a rewrited workaround for mimetypes if the requested file gzip compressed.

Test results:

```
Requested URI: /.nofn
{
  ["isScript"] = "false", 
  ["file"] = "http/.nofn", 
  ["ext"] = "nofn", 
  ["args"] =   {
    ["file"] = "http/.nofn", 
    ["ext"] = "nofn"
  }
}
Requested URI: /noext
{
  ["file"] = "http/noext", 
  ["isScript"] = "false", 
  ["args"] =   {
    ["file"] = "http/noext"
  }
}
Requested URI: /test.css
{
  ["isScript"] = "false", 
  ["file"] = "http/test.css", 
  ["ext"] = "css", 
  ["args"] =   {
    ["file"] = "http/test.css", 
    ["ext"] = "css"
  }
}
Requested URI: /test.min.css
{
  ["isScript"] = "false", 
  ["file"] = "http/test.min.css", 
  ["ext"] = "css", 
  ["args"] =   {
    ["file"] = "http/test.min.css", 
    ["ext"] = "css"
  }
}
Requested URI: /gztest.css
gzip variant exists, serving that one
{
  ["ext"] = "css", 
  ["args"] =   {
    ["file"] = "http/gztest.css.gz", 
    ["ext"] = "css", 
    ["gzipped"] = "true"
  }, 
  ["file"] = "http/gztest.css.gz", 
  ["isGzipped"] = "true", 
  ["isScript"] = "false"
}
Requested URI: /gztest.min.css
gzip variant exists, serving that one
{
  ["ext"] = "css", 
  ["args"] =   {
    ["file"] = "http/gztest.min.css.gz", 
    ["ext"] = "css", 
    ["gzipped"] = "true"
  }, 
  ["file"] = "http/gztest.min.css.gz", 
  ["isGzipped"] = "true", 
  ["isScript"] = "false"
}
Requested URI: /gztest
gzip variant exists, serving that one
{
  ["isGzipped"] = "true", 
  ["file"] = "http/gztest.gz", 
  ["isScript"] = "false", 
  ["args"] =   {
    ["file"] = "http/gztest.gz", 
    ["gzipped"] = "true"
  }
}
Requested URI: /gztest.gz
{
  ["isScript"] = "false", 
  ["file"] = "http/gztest.gz", 
  ["ext"] = "gz", 
  ["args"] =   {
    ["file"] = "http/gztest.gz", 
    ["ext"] = "gz"
  }
}
Requested URI: /lua.lua
{
  ["isScript"] = "true", 
  ["file"] = "http/lua.lua", 
  ["ext"] = "lua", 
  ["args"] =   {

  }
}
Requested URI: /lua.min.lua
{
  ["isScript"] = "true", 
  ["file"] = "http/lua.min.lua", 
  ["ext"] = "lua", 
  ["args"] =   {

  }
}
```
