### PR TITLE
File extension parsing, gzip detection and init.lua fix

### DIFF
--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -2,7 +2,7 @@
 -- Part of nodemcu-httpserver, knows how to send an HTTP header.
 -- Author: Marcos Kirsch
 
-return function (connection, code, extension)
+return function (connection, code, extension, gzip)
 
    local function getHTTPStatusString(code)
       local codez = {[200]="OK", [400]="Bad Request", [404]="Not Found",}
@@ -15,11 +15,6 @@ return function (connection, code, extension)
       local gzip = false
       -- A few MIME types. Keep list short. If you need something that is missing, let's add it.
       local mt = {css = "text/css", gif = "image/gif", html = "text/html", ico = "image/x-icon", jpeg = "image/jpeg", jpg = "image/jpeg", js = "application/javascript", json = "application/json", png = "image/png", xml = "text/xml"}
-      -- add comressed flag if file ends with gz
-      if ext:find("%.gz$") then
-          ext = ext:sub(1, -4)
-          gzip = true
-      end
       if mt[ext] then contentType = mt[ext] else contentType = "text/plain" end
       return {contentType = contentType, gzip = gzip}
    end
@@ -27,7 +22,7 @@ return function (connection, code, extension)
    local mimeType = getMimeType(extension)
 
    connection:send("HTTP/1.0 " .. code .. " " .. getHTTPStatusString(code) .. "\r\nServer: nodemcu-httpserver\r\nContent-Type: " .. mimeType["contentType"] .. "\r\n")
-   if mimeType["gzip"] then
+   if gzip then
        connection:send("Content-Encoding: gzip\r\n")
    end
    connection:send("Connection: close\r\n\r\n")

--- a/httpserver-request.lua
+++ b/httpserver-request.lua
@@ -94,7 +94,12 @@ local function parseUri(uri)
       filename,ext = filename:match("(.+)%.(.+)")
       table.insert(fullExt,1,ext)
    end
-   r.ext = table.concat(fullExt,".")
+   if #fullExt > 1 and fullExt[#fullExt] == 'gz' then
+      r.ext = fullExt[#fullExt-1]
+      r.isGzipped = true
+   elseif #fullExt >= 1 then
+      r.ext = fullExt[#fullExt]
+   end
    r.isScript = r.ext == "lua" or r.ext == "lc"
    r.file = uriToFilename(r.file)
    return r

--- a/httpserver-static.lua
+++ b/httpserver-static.lua
@@ -3,7 +3,7 @@
 -- Author: Marcos Kirsch
 
 return function (connection, req, args)
-   dofile("httpserver-header.lc")(connection, 200, args.ext)
+   dofile("httpserver-header.lc")(connection, 200, args.ext, args.gzipped)
    --print("Begin sending:", args.file)
    -- Send file in little chunks
    local continue = true

--- a/httpserver.lua
+++ b/httpserver.lua
@@ -40,7 +40,7 @@ return function (port)
                  if fileExists then
                     print("gzip variant exists, serving that one")
                     uri.file = uri.file .. ".gz"
-                    uri.ext = uri.ext .. ".gz"
+                    uri.isGzipped = true
                  end
                end
 
@@ -51,7 +51,7 @@ return function (port)
                   fileServeFunction = dofile(uri.file)
                else
                   if allowStatic[method] then
-                    uri.args = {file = uri.file, ext = uri.ext}
+                    uri.args = {file = uri.file, ext = uri.ext, gzipped = uri.isGzipped}
                     fileServeFunction = dofile("httpserver-static.lc")
                   else
                     uri.args = {code = 405, errorString = "Method not supported"}

--- a/init.lua
+++ b/init.lua
@@ -89,7 +89,7 @@ if (wifi.getmode() == wifi.STATION) or (wifi.getmode() == wifi.STATIONAP) then
 end
 
 -- Uncomment to automatically start the server in port 80
-if (not not wifi.sta.getip()) or (not not wifi.ap.getip()l) then
+if (not not wifi.sta.getip()) or (not not wifi.ap.getip()) then
     dofile("httpserver.lc")(80)    
 end
 


### PR DESCRIPTION
- Modified the file extension parsing so it can select correct mimetype for filenames contain multiple dots like zepto.min.js
- Modified the gzip detection logic
- Deleted stray character at init.lua causing the syntax error
