### PR TITLE
Added handling of watchdog for serving bigger files

### DIFF
--- a/httpserver-header.lua
+++ b/httpserver-header.lua
@@ -23,6 +23,7 @@ return function (connection, code, extension, gzip)
 
    connection:send("HTTP/1.0 " .. code .. " " .. getHTTPStatusString(code) .. "\r\nServer: nodemcu-httpserver\r\nContent-Type: " .. mimeType["contentType"] .. "\r\n")
    if gzip then
+       connection:send("Cache-Control: max-age=2592000\r\n")
        connection:send("Content-Encoding: gzip\r\n")
    end
    connection:send("Connection: close\r\n\r\n")

--- a/httpserver-static.lua
+++ b/httpserver-static.lua
@@ -23,6 +23,7 @@ return function (connection, req, args)
          connection:send(chunk)
          bytesSent = bytesSent + #chunk
          chunk = nil
+         tmr.wdclr() -- loop can take a while for long files. tmr.wdclr() prevent watchdog to restart module
          --print("Sent" .. args.file, bytesSent)
       end
    end


### PR DESCRIPTION
If we serve bigger files (for example Twitter bootstrap files) watchdog causes module restarts.
