### PR TITLE
matching of mime type in http request header that contain a charset a…

### DIFF
--- a/httpserver-request.lua
+++ b/httpserver-request.lua
@@ -51,7 +51,7 @@ local function getRequestData(payload)
     if requestData then
       return requestData
     else
-      local mimeType = string.match(payload, "Content%-Type: (%S+)\r\n")
+      local mimeType = string.match(payload, "Content%-Type: ([%w/-]+)")
       local body_start = payload:find("\r\n\r\n", 1, true)
       local body = payload:sub(body_start, #payload)
       payload = nil


### PR DESCRIPTION
…ppendix

When the Content-Type header is for example:
Content-Type: application/x-www-form-urlencode; charset=utf-8
The old regex matches to much, preventing the code further down to parse the body.
