### PR TITLE
modularize nodemcu-command, add start_baud parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ NODEMCU-UPLOADER=../nodemcu-uploader/nodemcu-uploader.py
 PORT=/dev/cu.SLAB_USBtoUART
 SPEED=9600
 
+NODEMCU-COMMAND=$(NODEMCU-UPLOADER) -b $(SPEED) --start_baud $(SPEED) -p $(PORT) upload
+
 ######################################################################
 # End of user config
 ######################################################################
@@ -33,17 +35,17 @@ usage:
 
 # Upload one files only
 upload:
-	@python $(NODEMCU-UPLOADER) -b $(SPEED) -p $(PORT) upload $(FILE)
+	@python $(NODEMCU-COMMAND) $(FILE)
 
 # Upload HTTP files only
 upload_http: $(HTTP_FILES)
-	@python $(NODEMCU-UPLOADER) -b $(SPEED) -p $(PORT) upload $(foreach f, $^, $(f))
+	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
 
 # Upload httpserver lua files (init and server module)
 upload_server: $(LUA_FILES)
-	@python $(NODEMCU-UPLOADER) -b $(SPEED) -p $(PORT) upload $(foreach f, $^, $(f))
+	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
 
 # Upload all
 upload_all: $(LUA_FILES) $(HTTP_FILES)
-	@python $(NODEMCU-UPLOADER) -b $(SPEED) -p $(PORT) upload $(foreach f, $^, $(f))
+	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
 


### PR DESCRIPTION
Easier configuration of nodemcu-uploader command. Might use --compile or other features.

Added start_boud parameter - working perfectly with current nodemcu firmware (master)