### PR TITLE
filter invalid requests

### DIFF
--- a/httpserver-request.lua
+++ b/httpserver-request.lua
@@ -112,6 +112,11 @@ return function (request)
    local line = request:sub(1, e - 1)
    local r = {}
    _, i, r.method, r.request = line:find("^([A-Z]+) (.-) HTTP/[1-9]+.[0-9]+$")
+   if not (r.method and r.request) then
+      --print("invalid request: ")
+      --print(request)
+      return nil
+   end
    r.methodIsValid = validateMethod(r.method)
    r.uri = parseUri(r.request)
    r.getRequestData = getRequestData(request)


### PR DESCRIPTION
sometimes I observe requests which are malformed (seem to be binary
data) so everything that does not have a method and request (url)
defined gets kicked.