### PR TITLE
now use proper table based parameter for wifi.ap.setip

### DIFF
--- a/httpserver-conf.lua
+++ b/httpserver-conf.lua
@@ -20,9 +20,9 @@ if (conf.wifi.mode == wifi.SOFTAP) or (conf.wifi.mode == wifi.STATIONAP) then
    conf.wifi.accessPoint.config = {}
    conf.wifi.accessPoint.config.ssid = "ESP-"..node.chipid() -- Name of the WiFi network to create.
    conf.wifi.accessPoint.config.pwd = "ESP-"..node.chipid() -- WiFi password for joining - at least 8 characters
-   conf.wifi.accessPoint.ip = "192.168.111.1"
---   conf.wifi.accessPoint.netmask = "255.255.255.0"
---   conf.wifi.accessPoint.gateway = "192.168.111.1"
+   conf.wifi.accessPoint.net.ip = "192.168.111.1"
+   conf.wifi.accessPoint.net.netmask="255.255.255.0"
+   conf.wifi.accessPoint.net.gateway="192.168.111.1" }
 end
 -- These apply only when connecting to a router as a client
 if (conf.wifi.mode == wifi.STATION) or (conf.wifi.mode == wifi.STATIONAP) then

--- a/httpserver-wifi.lua
+++ b/httpserver-wifi.lua
@@ -14,7 +14,7 @@ wifi.setmode(conf.wifi.mode)
 if (conf.wifi.mode == wifi.SOFTAP) or (conf.wifi.mode == wifi.STATIONAP) then
     print('AP MAC: ',wifi.ap.getmac())
     wifi.ap.config(conf.wifi.accessPoint.config)
-    wifi.ap.setip(conf.wifi.accessPoint.ip)
+    wifi.ap.setip(conf.wifi.accessPoint.net)
 end
 
 if (conf.wifi.mode == wifi.STATION) or (conf.wifi.mode == wifi.STATIONAP) then


### PR DESCRIPTION
Use a proper table for wifi.ap.setip instead of a string.

This is related with #103 where the NodeMCU's wifi object changed part of it's API.