### PR TITLE
Fix my mistake in config file

### DIFF
--- a/httpserver-conf.lua
+++ b/httpserver-conf.lua
@@ -20,9 +20,10 @@ if (conf.wifi.mode == wifi.SOFTAP) or (conf.wifi.mode == wifi.STATIONAP) then
    conf.wifi.accessPoint.config = {}
    conf.wifi.accessPoint.config.ssid = "ESP-"..node.chipid() -- Name of the WiFi network to create.
    conf.wifi.accessPoint.config.pwd = "ESP-"..node.chipid() -- WiFi password for joining - at least 8 characters
+   conf.wifi.accessPoint.net = {}
    conf.wifi.accessPoint.net.ip = "192.168.111.1"
    conf.wifi.accessPoint.net.netmask="255.255.255.0"
-   conf.wifi.accessPoint.net.gateway="192.168.111.1" }
+   conf.wifi.accessPoint.net.gateway="192.168.111.1"
 end
 -- These apply only when connecting to a router as a client
 if (conf.wifi.mode == wifi.STATION) or (conf.wifi.mode == wifi.STATIONAP) then


### PR DESCRIPTION
Sorry for the mess here (I have to triple check merges) :/

This is fixed and tested:
with
conf.wifi.mode = wifi.SOFTAP

```
$ make upload_server
[...]
$ screen /dev/ttyUSB0 115200
  [Reset button pressed]
NodeMCU custom build by frightanic.com
        branch: master
        commit: 2e67ff5a639a13260fd4fb3c3b627ccdc2845616
        SSL: false
        modules: adc,enduser_setup,file,gpio,i2c,net,node,spi,tmr,u8g,uart,wifi,ws2801
 build  built on: 2017-09-01 11:08
 powered by Lua 5.1.4 on SDK 2.1.0(116b762)
Compiling:      httpserver.lua
Compiling:      httpserver-b64decode.lua
Compiling:      httpserver-basicauth.lua
Compiling:      httpserver-compile.lua
Compiling:      httpserver-conf.lua
Compiling:      httpserver-connection.lua
Compiling:      httpserver-error.lua
Compiling:      httpserver-header.lua
Compiling:      httpserver-init.lua
Compiling:      httpserver-request.lua
Compiling:      httpserver-static.lua
Compiling:      httpserver-wifi.lua
AP MAC:         62:01:94:33:96:8e
chip:   3380878
heap:   35304
nodemcu-httpserver running at:
   http://192.168.111.1:80
> 

```
