### PR TITLE
Efficient static serving

### DIFF
--- a/httpserver-connection.lua
+++ b/httpserver-connection.lua
@@ -5,7 +5,7 @@
 -- flush() and for closing the connection.
 -- Author: Philip Gladstone, Marcos Kirsch
 
-BufferedConnection = {}
+local BufferedConnection = {}
 
 -- parameter is the nodemcu-firmware connection
 function BufferedConnection:new(connection)

--- a/httpserver-static.lua
+++ b/httpserver-static.lua
@@ -4,6 +4,8 @@
 
 return function (connection, req, args)
    dofile("httpserver-header.lc")(connection, 200, args.ext, args.isGzipped)
+   connection:flush()
+   coroutine.yield()
    -- Send file in little chunks
    local bytesRemaining = file.list()[args.file]
    -- Chunks larger than 1024 don't work.
@@ -13,9 +15,9 @@ return function (connection, req, args)
    while bytesRemaining > 0 do
       local bytesToRead = 0
       if bytesRemaining > chunkSize then bytesToRead = chunkSize else bytesToRead = bytesRemaining end
-      local chunk = fileHandle:read(bytesToRead)
-      connection:send(chunk)
-      bytesRemaining = bytesRemaining - #chunk
+      connection.connection:send(fileHandle:read(bytesToRead)) 
+      coroutine.yield()
+      bytesRemaining = bytesRemaining - bytesToRead
       --print(args.file .. ": Sent "..#chunk.. " bytes, " .. bytesRemaining .. " to go.")
       chunk = nil
       collectgarbage()

--- a/httpserver.lua
+++ b/httpserver.lua
@@ -60,6 +60,7 @@ return function (port)
                -- nodemcu-firmware cannot handle long filenames.
                uri.args = {code = 400, errorString = "Bad Request", logFunction = log}
                fileServeFunction = dofile("httpserver-error.lc")
+               req=nil
             else
                local fileExists = false
 
@@ -79,15 +80,18 @@ return function (port)
                if not fileExists then
                   uri.args = {code = 404, errorString = "Not Found", logFunction = log}
                   fileServeFunction = dofile("httpserver-error.lc")
+                  req=nil
                elseif uri.isScript then
                   fileServeFunction = dofile(uri.file)
                else
                   if allowStatic[method] then
                      uri.args = {file = uri.file, ext = uri.ext, isGzipped = uri.isGzipped}
                      fileServeFunction = dofile("httpserver-static.lc")
+                     req=nil
                   else
                      uri.args = {code = 405, errorString = "Method not supported", logFunction = log}
                      fileServeFunction = dofile("httpserver-error.lc")
+                     req=nil
                   end
                end
             end


### PR DESCRIPTION
Simple changes focussed on static file serving:
Drops the req table when it's never used by the fileServeFunctions, (-static and -error) by setting it to nil.
Uses the socket directly in the bulk of httpserver-static.lua to avoid using buffers.
Will reduce amount sent per packet to 1024 bytes from 1400, but will save at least that amount of active memory, or probably more since buffer manipulation, etc.
And makes bufferedConnection local, to prevent it being a global (to save memory - anything that uses it has a local copy anyway)