### PR TITLE
edit Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,18 +3,24 @@
 ######################################################################
 
 # Path to nodemcu-uploader (https://github.com/kmpm/nodemcu-uploader)
-NODEMCU-UPLOADER=../nodemcu-uploader/nodemcu-uploader.py
+NODEMCU-UPLOADER?=python ../nodemcu-uploader/nodemcu-uploader.py
 
 # Serial port
-PORT=/dev/cu.SLAB_USBtoUART
-SPEED=115200
+PORT?=/dev/cu.SLAB_USBtoUART
+SPEED?=115200
 
-NODEMCU-COMMAND=$(NODEMCU-UPLOADER) -b $(SPEED) --start_baud $(SPEED) -p $(PORT) upload
+define _upload
+@$(NODEMCU-UPLOADER) -b $(SPEED) --start_baud $(SPEED) -p $(PORT) upload $^
+endef
 
 ######################################################################
 
+LFS_IMAGE ?= lfs.img
 HTTP_FILES := $(wildcard http/*)
-LUA_FILES := $(wildcard *.lua)
+WIFI_CONFIG := $(wildcard *conf*.lua)
+SERVER_FILES := $(filter-out $(WIFI_CONFIG), $(wildcard srv/*.lua) $(wildcard *.lua))
+LFS_FILES := $(LFS_IMAGE) $(filter-out $(WIFI_CONFIG), $(wildcard *.lua))
+FILE ?=
 
 # Print usage
 usage:
@@ -22,21 +28,39 @@ usage:
 	@echo "make upload_http          to upload files to be served"
 	@echo "make upload_server        to upload the server code and init.lua"
 	@echo "make upload_all           to upload all"
-	@echo $(TEST)
 
 # Upload one files only
-upload:
-	@python $(NODEMCU-COMMAND) $(FILE)
+upload: $(FILE)
+	$(_upload)
 
 # Upload HTTP files only
 upload_http: $(HTTP_FILES)
-	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
+	$(_upload)
 
-# Upload httpserver lua files (init and server module)
-upload_server: $(LUA_FILES)
-	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
+# Upload httpserver lua files
+upload_server: $(SERVER_FILES)
+	$(_upload)
 
-# Upload all
-upload_all: $(LUA_FILES) $(HTTP_FILES)
-	@python $(NODEMCU-COMMAND) $(foreach f, $^, $(f))
+# Upload wifi configuration
+upload_wifi_config: $(WIFI_CONFIG)
+	$(_upload)
 
+# Upload lfs image
+upload_lfs: $(LFS_FILES)
+	$(_upload)
+
+# Throw error if lfs file not found
+$(LFS_IMAGE):
+	$(error File $(LFS_IMAGE) not found)
+
+# Upload all non-lfs files
+upload_all: $(HTTP_FILES) $(SERVER_FILES) $(WIFI_CONFIG)
+	$(_upload)
+
+# Upload all lfs files
+upload_all_lfs: $(HTTP_FILES) $(LFS_FILES) $(WIFI_CONFIG)
+	$(_upload)
+
+.ENTRY: usage
+.PHONY: usage upload_http upload_server upload_wifi_config \
+upload_lfs upload_all upload_all_lfs

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Let the abuse begin.
 
          make upload_server
 
+   If you only want to update wifi configuration, type:
+
+         make upload_wifi_config
+
    And if you only want to upload just the files that can be served:
 
          make upload_http
@@ -98,7 +102,7 @@ Let the abuse begin.
 
    1. Compile contents of `srv` into LFS image. There's a [cloud service](https://blog.ellisons.org.uk/article/nodemcu/a-lua-cross-compile-web-service/) and [docker image](https://github.com/marcelstoer/docker-nodemcu-build) that will help you with that.
 
-   1. Upload image file under `lfs.img` name.
+   1. Upload image file under `lfs.img` name. You may use Makefile rules `upload_lfs` and `upload_all_lfs` for this.
 
    1. Reboot you NodeMCU. Init script will pick up image and apply it for you.
 


### PR DESCRIPTION
This is followup to #125.
- Old rules preserved for the most part.
- `upload_config` is added in order to upload wifi configuration.
- `upload_lfs` uploads `lfs.img` or throws error if it is not found.
- `upload_all_lfs` does the same job as `upload_all`, but for lfs.
