### PR TITLE
add nodemcu-tool upload option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,26 @@
 ######################################################################
 
 # Path to nodemcu-uploader (https://github.com/kmpm/nodemcu-uploader)
-NODEMCU-UPLOADER?=python ../nodemcu-uploader/nodemcu-uploader.py
+NODEMCU_UPLOADER?=python ../nodemcu-uploader/nodemcu-uploader.py
+
+# Path to nodemcu-tool (https://github.com/AndiDittrich/NodeMCU-Tool)
+NODEMCU_TOOL?=../nodemcu-tool/node_modules/nodemcu-tool/bin/nodemcu-tool.js
+
+USE_NODEMCU_TOOL?=
 
 # Serial port
 PORT?=/dev/cu.SLAB_USBtoUART
 SPEED?=115200
 
+ifdef USE_NODEMCU_TOOL
 define _upload
-@$(NODEMCU-UPLOADER) -b $(SPEED) --start_baud $(SPEED) -p $(PORT) upload $^
+@$(NODEMCU_TOOL) -b $(SPEED) --baud $(SPEED) -p $(PORT) upload --keeppath $^
 endef
+else
+define _upload
+@$(NODEMCU_UPLOADER) -b $(SPEED) --start_baud $(SPEED) -p $(PORT) upload $^
+endef
+endif
 
 ######################################################################
 
@@ -62,5 +73,6 @@ upload_all_lfs: $(HTTP_FILES) $(LFS_FILES) $(WIFI_CONFIG)
 	$(_upload)
 
 .ENTRY: usage
+MAKEFLAGS: --always-make
 .PHONY: usage upload_http upload_server upload_wifi_config \
 upload_lfs upload_all upload_all_lfs

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Let the abuse begin.
 
 1. Modify your local copy of the configuration file httpserver-conf.lua.
 
-2. Upload server files using [nodemcu-uploader](https://github.com/kmpm/nodemcu-uploader).
+2. Upload server files using [nodemcu-uploader](https://github.com/kmpm/nodemcu-uploader) or [nodemcu-tool](https://github.com/AndiDittrich/NodeMCU-Tool).
    The easiest is to use GNU Make with the bundled Makefile. Open the Makefile and modify the
    user configuration to point to your nodemcu-uploader script and your serial port.
    Type the following to upload the server code, init.lua (which you may want to modify),
@@ -48,6 +48,10 @@ Let the abuse begin.
 
    Restart the server. This will execute included init.lua which will compile the server code,
    configure WiFi, and start the server.
+
+   nodemcu-uploader is used by default. In order to switch to nodemcu-tool, use option `USE_NODEMCU_TOOL`. For example, to upload wifi configuration using nodemcu-tool, use command:
+
+         make upload_wifi_config USE_NODEMCU_TOOL=1
 
 3. Want to serve your own files? Put them under the http/ folder and upload to the chip.
    For example, assuming you want to serve myfile.html, upload by typing:


### PR DESCRIPTION
In light of #127 it would be useful to have two options for uploading files. This PR adds ability to use `nodemcu-tool` instead of `nodemcu-uploader`. This feature is controlled by make `USE_NODEMCU_TOOL` variable.

For example, following command will use `nodemcu-uploader` to upload file `http/underconstruction.gif`:
```bash
make upload FILE=http/underconstruction.gif PORT=/dev/ttyUSB0
```
This command will use `nodemcu-tool`:
```bash
make upload FILE=http/underconstruction.gif PORT=/dev/ttyUSB0 USE_NODEMCU_TOOL=1
```